### PR TITLE
fix home reference for setups where relative_base_url would be empty

### DIFF
--- a/templates/categories.html.twig
+++ b/templates/categories.html.twig
@@ -8,7 +8,7 @@
     <main id="summer-page-container" class="summer-page-container" role="main">
         <header class="summer-page-header">
             <div class="summer-page-menu-header">
-                <a class="summer-blog-logo" href="{{ base_url }}">
+                <a class="summer-blog-logo" href="{{ base_url_absolute }}">
                     <img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" />
                 </a>
 

--- a/templates/featured.html.twig
+++ b/templates/featured.html.twig
@@ -8,7 +8,7 @@
     <main id="summer-page-container" class="summer-page-container" role="main">
         <header class="summer-page-header">
             <div class="summer-page-menu-header">
-                <a class="summer-blog-logo" href="{{ base_url }}">
+                <a class="summer-blog-logo" href="{{ base_url_absolute }}">
                     <img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" />
                 </a>
 

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -8,7 +8,7 @@
     <main id="summer-page-container" class="summer-page-container" role="main">
         <header class="summer-page-header">
             <div class="summer-page-menu-header">
-                <a class="summer-blog-logo" href="{{ base_url }}">
+                <a class="summer-blog-logo" href="{{ basebase_url_absolute_url }}">
                     <img src="{{ base_url }}{{ site.logo }}" alt="Blog Logo" /></a>
                 </a>
 

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -82,7 +82,7 @@
         {% block header %}
             <header class="summer-site-head">
                 <div class="summer-site-head-menu">
-                    <a class="summer-blog-logo" href="{{ base_url }}"><img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" /></a>
+                    <a class="summer-blog-logo" href="{{ base_url_absolute }}"><img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" /></a>
                     {% include 'partials/navigation.html.twig' %}
                     <div class="clearfix"></div>
                 </div>

--- a/templates/partials/navigation.html.twig
+++ b/templates/partials/navigation.html.twig
@@ -6,7 +6,7 @@
         <li class="summer-mobile-close-btn show-for-small text-right">
             <a href="#"><i class="fa fa-times"></i></a>
         </li>
-        <li><a href="{{ base_url_relative }}">Home</a></li>
+        <li><a href="{{ base_url_absolute }}">Home</a></li>
         {% for link in site.links %}
             {% if link.url | contains('http') %}
                 {% set domain = '' %}

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -10,7 +10,7 @@
   <header class="summer-post-header">
     <div class="bg-img"></div>
     <div class="summer-post-menu-header">
-      <a class="summer-blog-logo" href="{{ base_url }}">
+      <a class="summer-blog-logo" href="{{ base_url_absolute }}">
         <img src="{{ base_url }}{{ site.logo }}" alt="Blog Logo" />
       </a>
       {% include 'partials/navigation.html.twig' %}


### PR DESCRIPTION
This happens when your grav root folder is the same as your webroot, i.e. no subfolder sites.

Don't know if using base_url_absolute is the best way, but it works, I've also seen antimatter use `{{ base_url == '' ? '/' : base_url }}`
