### PR TITLE
Fixed not using date set in the post's header

### DIFF
--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -17,7 +17,7 @@
     </div>
     <div class="summer-post-title bg-check">
       <h1>{{ page.title }}</h1>
-      <p>by <strong>{{ site.owner.name }}</strong> &#8212; on {% for tag in page.taxonomy.tag %}<a href="{{ site.url }}/tags/index.html#{{ tag }}" data-toggle="tooltip" title="Posts tagged with {{ tag }}" rel="tag">{{ tag }}</a>{%if not loop.last %}&nbsp;&comma;&nbsp;{% endif %}{% endfor %} <strong><time datetime="{{ page.date | date(site.date_long) }}">{{ post.date | date("d M Y") }}</time></strong></p>
+      <p>by <strong>{{ site.owner.name }}</strong> &#8212; on {% for tag in page.taxonomy.tag %}<a href="{{ site.url }}/tags/index.html#{{ tag }}" data-toggle="tooltip" title="Posts tagged with {{ tag }}" rel="tag">{{ tag }}</a>{%if not loop.last %}&nbsp;&comma;&nbsp;{% endif %}{% endfor %} <strong><time datetime="{{ page.date | date(site.date_long) }}">{{ page.date | date("d M Y") }}</time></strong></p>
     </div>
     <div class="bg-img"></div>
   </header>


### PR DESCRIPTION
As it was, it will show the modified date instead of the date set explicitly in the post header, although the data in the time tag was correct. So basically using page.date instead of post.date.
