### PR TITLE
Fixes 404 when clicking tag while viewing post

### DIFF
--- a/templates/partials/article.html.twig
+++ b/templates/partials/article.html.twig
@@ -24,7 +24,7 @@
        </section>
        
        <div class="summer-index-post-tags">
-        {% for tag in post.taxonomy.tag %}<span class="post-tag-{{tag}}"><a href="{{ home.url }}/tag{{ config.system.param_sep }}{{ tag }}">{{ tag }}</a></span>{%if not loop.last %} {% endif %}{% endfor %}
+        {% for tag in post.taxonomy.tag %}<span class="post-tag-{{tag}}"><a href="{{ site.url }}/tag{{ config.system.param_sep }}{{ tag }}">{{ tag }}</a></span>{%if not loop.last %} {% endif %}{% endfor %}
         </div>
         
     </div>

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -17,7 +17,7 @@
     </div>
     <div class="summer-post-title bg-check">
       <h1>{{ page.title }}</h1>
-      <p>by <strong>{{ site.owner.name }}</strong> &#8212; on {% for tag in page.taxonomy.tag %}<a href="{{ site.url }}/tags/index.html#{{ tag }}" data-toggle="tooltip" title="Posts tagged with {{ tag }}" rel="tag">{{ tag }}</a>{%if not loop.last %}&nbsp;&comma;&nbsp;{% endif %}{% endfor %} <strong><time datetime="{{ page.date | date(site.date_long) }}">{{ post.date | date("d M Y") }}</time></strong></p>
+      <p>by <strong>{{ site.owner.name }}</strong> &#8212; on {% for tag in page.taxonomy.tag %}<a href="{{ site.url }}/tag:{{ tag }}" data-toggle="tooltip" title="Posts tagged with {{ tag }}" rel="tag">{{ tag }}</a>{%if not loop.last %}&nbsp;&comma;&nbsp;{% endif %}{% endfor %} <strong><time datetime="{{ page.date | date(site.date_long) }}">{{ post.date | date("d M Y") }}</time></strong></p>
     </div>
     <div class="bg-img"></div>
   </header>


### PR DESCRIPTION
You can see this on the demo site, clicking a tag link results in a 404: http://demo.getgrav.org/tags/index.html#grav

Not sure if you had some other plans for that tags/index page, but this makes it work as-is.
