### PR TITLE
Perform background check after images are loaded

### DIFF
--- a/js/summerb146.js
+++ b/js/summerb146.js
@@ -39,9 +39,18 @@ var summer = (function ($) {
 
     headerTitlesBackgroundCheck = function () {
         if ($(bgCheckClass).length && $(postBgImages).length) {
-            BackgroundCheck.init({
-                targets: bgCheckClass,
-                images: postBgImages
+            var images = $(postBgImages);
+            var counter = 0;
+            images.each(function() {
+                $(this).load(function() {
+                    counter++;
+                    if (counter === images.length) {
+                        BackgroundCheck.init({
+                            targets: bgCheckClass,
+                            images: postBgImages
+                        });
+                    }
+                })
             });
         }
     },


### PR DESCRIPTION
Hi guys,

first of all thanks for an amazing template. I like it very much.

I started playing with it recently and noticed that background check feature sometimes doesn't work properly. I dug a little bit and it looks like the script is not taking into account when images are loaded. When JS script starts before images are loaded (for example when all assets are cached in a browser), background check is incorrect.

My fix forces the script to wait until all checked images are loaded. Please merge it if you want.

Best regards,
Michał Biarda