### PR TITLE
Add a check to see if on top of screen

### DIFF
--- a/js/vendor/post-header-animationsb146.js
+++ b/js/vendor/post-header-animationsb146.js
@@ -38,10 +38,12 @@
         }
 
         function keydown(e) {
-            for (var i = keys.length; i--;) {
-                if (e.keyCode === keys[i]) {
-                    preventDefault(e);
-                    return;
+            if (window.scrollTop > 5) {
+                for (var i = keys.length; i--;) {
+                    if (e.keyCode === keys[i]) {
+                        preventDefault(e);
+                        return;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This modification is to fix a bug where multiple keydown events are blocked and prevent writing in fields if the page was reloaded.

In my specific use-case, reloading the page when looking at the comment section on the bottom of the page will prevent the user from writing spaces in the fields.