### PR TITLE
Add alt attribute on blog logo and on banner images

### DIFF
--- a/js/summerb146.js
+++ b/js/summerb146.js
@@ -47,9 +47,9 @@ var summer = (function ($) {
     },
 
     postHeaderCoverImg = function () {
-        var coverImage = $('[alt=cover-image]');
+        var coverImage = $('#cover-image');
         if (coverImage.length) {
-            $(postCoverImg).append('<img src="' + coverImage.attr('src') + '">');
+            $(postCoverImg).append('<img src="' + coverImage.attr('src') + '" alt="' + coverImage.attr('alt') + '">');
             coverImage.remove();
         }
     },

--- a/templates/categories.html.twig
+++ b/templates/categories.html.twig
@@ -9,7 +9,7 @@
         <header class="summer-page-header">
             <div class="summer-page-menu-header">
                 <a class="summer-blog-logo" href="{{ base_url_absolute }}">
-                    <img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" />
+                    <img src="{{ base_url_relative }}{{ site.logo }}" alt="{{ site.title }}" />
                 </a>
 
                 {% include 'partials/navigation.html.twig' %}

--- a/templates/featured.html.twig
+++ b/templates/featured.html.twig
@@ -9,7 +9,7 @@
         <header class="summer-page-header">
             <div class="summer-page-menu-header">
                 <a class="summer-blog-logo" href="{{ base_url_absolute }}">
-                    <img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" />
+                    <img src="{{ base_url_relative }}{{ site.logo }}" alt="{{ site.title }}" />
                 </a>
 
                 {% include 'partials/navigation.html.twig' %}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -9,7 +9,7 @@
         <header class="summer-page-header">
             <div class="summer-page-menu-header">
                 <a class="summer-blog-logo" href="{{ basebase_url_absolute_url }}">
-                    <img src="{{ base_url }}{{ site.logo }}" alt="Blog Logo" /></a>
+                    <img src="{{ base_url }}{{ site.logo }}" alt="{{ site.title }}" /></a>
                 </a>
 
                 {% include 'partials/navigation.html.twig' %}

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -56,7 +56,7 @@
         {% block header %}
             <header class="summer-site-head">
                 <div class="summer-site-head-menu">
-                    <a class="summer-blog-logo" href="{{ base_url == '' ? '/' : base_url }}"><img src="{{ base_url_relative }}{{ site.logo }}" alt="Blog Logo" /></a>
+                    <a class="summer-blog-logo" href="{{ base_url == '' ? '/' : base_url }}"><img src="{{ base_url_relative }}{{ site.logo }}" alt="{{ site.title }}" /></a>
                     {% include 'partials/navigation.html.twig' %}
                     <div class="clearfix"></div>
                 </div>

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -6,12 +6,13 @@
 {% block header %}{% endblock %}
 
 {% block content %}
+
  <main id="summer-post-container" class="summer-post-container intro-effect-sliced" role="main">
   <header class="summer-post-header">
     <div class="bg-img"></div>
     <div class="summer-post-menu-header">
       <a class="summer-blog-logo" href="{{ base_url_absolute }}">
-        <img src="{{ base_url }}{{ site.logo }}" alt="Blog Logo" />
+        <img src="{{ base_url }}{{ site.logo }}" alt="{{ site.title }}" />
       </a>
       {% include 'partials/navigation.html.twig' %}
     </div>
@@ -24,7 +25,12 @@
 
   <button class="trigger bg-check" data-info="Read more"><span>Trigger</span></button>
 
-  {% if page.header.image %}<img src="{{ page.media[page.header.image].url }}" alt="cover-image" />{% endif %}
+  {% set headerAlt = page.title %}
+  {% if page.header.imageAlt %}
+    {% set headerAlt = page.header.imageAlt %}
+  {% endif %}
+
+  {% if page.header.image %}<img src="{{ page.media[page.header.image].url }}" id="cover-image" alt="{{ headerAlt }}" />{% endif %}
 
     <article class="summer-post-content post">
       <div>


### PR DESCRIPTION
For banner images, it will default to the post title, but with the ability to manually set one using the imageAlt property in the markdown header